### PR TITLE
Proxy StartTLS SMTP connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Makefile
+objs

--- a/auto/modules
+++ b/auto/modules
@@ -950,6 +950,16 @@ if [ $MAIL != NO ]; then
         . auto/module
     fi
 
+    if [ $MAIL_SNI_PROXY = YES ]; then
+        have=NGX_MAIL_SNI_PROXY . auto/have
+
+        ngx_module_name=ngx_mail_sni_proxy_module
+        ngx_module_deps=src/mail/ngx_mail_sni_proxy_module.h
+        ngx_module_srcs=src/mail/ngx_mail_sni_proxy_module.c
+
+        . auto/module
+    fi
+
     if [ $MAIL_POP3 = YES ]; then
         ngx_module_name=ngx_mail_pop3_module
         ngx_module_deps=src/mail/ngx_mail_pop3_module.h

--- a/auto/options
+++ b/auto/options
@@ -113,6 +113,7 @@ MAIL_SSL=NO
 MAIL_POP3=YES
 MAIL_IMAP=YES
 MAIL_SMTP=YES
+MAIL_SNI_PROXY=NO
 
 STREAM=NO
 STREAM_SSL=NO
@@ -295,6 +296,7 @@ $0: warning: the \"--with-ipv6\" option is deprecated"
         --with-mail=dynamic)             MAIL=DYNAMIC               ;;
         --with-mail_ssl_module)          MAIL_SSL=YES               ;;
         # STUB
+        --with-mail_sni_module)          MAIL_SNI_PROXY=YES         ;;
         --with-imap)
             MAIL=YES
             NGX_POST_CONF_MSG="$NGX_POST_CONF_MSG

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -419,7 +419,7 @@ ngx_int_t ngx_mail_realip_handler(ngx_mail_session_t *s);
 /**/
 
 #if (NGX_MAIL_SNI_PROXY)
-void ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c);
+ngx_int_t ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c);
 #endif
 
 extern ngx_uint_t    ngx_mail_max_module;

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -421,6 +421,7 @@ ngx_int_t ngx_mail_realip_handler(ngx_mail_session_t *s);
 #if (NGX_MAIL_SNI_PROXY)
 ngx_int_t ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c);
 void ngx_mail_sni_starttls_handler(ngx_event_t *rev);
+void ngx_mail_sni_proxy_connection_init(ngx_mail_session_t *s, ngx_addr_t *peer);
 #endif
 
 extern ngx_uint_t    ngx_mail_max_module;

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -18,6 +18,9 @@
 #include <ngx_mail_ssl_module.h>
 #endif
 
+#if (NGX_MAIL_SNI_PROXY)
+#include <ngx_mail_sni_proxy_module.h>
+#endif
 
 
 typedef struct {
@@ -380,7 +383,6 @@ typedef struct {
 void ngx_mail_starttls_handler(ngx_event_t *rev);
 ngx_int_t ngx_mail_starttls_only(ngx_mail_session_t *s, ngx_connection_t *c);
 #endif
-
 
 void ngx_mail_init_connection(ngx_connection_t *c);
 

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -420,6 +420,7 @@ ngx_int_t ngx_mail_realip_handler(ngx_mail_session_t *s);
 
 #if (NGX_MAIL_SNI_PROXY)
 ngx_int_t ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c);
+void ngx_mail_sni_starttls_handler(ngx_event_t *rev);
 #endif
 
 extern ngx_uint_t    ngx_mail_max_module;

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -176,7 +176,9 @@ typedef enum {
     ngx_smtp_xclient_helo,
     ngx_smtp_xclient_auth,
     ngx_smtp_from,
-    ngx_smtp_to
+    ngx_smtp_to,
+    ngx_smtp_starttls,
+    ngx_smtp_proxy_tls
 } ngx_smtp_state_e;
 
 

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -178,6 +178,7 @@ typedef enum {
     ngx_smtp_from,
     ngx_smtp_to,
     ngx_smtp_starttls,
+    ngx_smtp_proxy_tls_handshake,
     ngx_smtp_proxy_tls
 } ngx_smtp_state_e;
 

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -418,6 +418,9 @@ void ngx_mail_auth_http_init(ngx_mail_session_t *s);
 ngx_int_t ngx_mail_realip_handler(ngx_mail_session_t *s);
 /**/
 
+#if (NGX_MAIL_SNI_PROXY)
+void ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c);
+#endif
 
 extern ngx_uint_t    ngx_mail_max_module;
 extern ngx_module_t  ngx_mail_core_module;

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -1478,10 +1478,11 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
 #endif
 
 #if (NGX_MAIL_SNI_PROXY)
-
-    b->last = ngx_cpymem(b->last, "Destination-SNI: ", sizeof("Destination-SNI: ") - 1);
-    b->last = ngx_copy(b->last, sni_ctx->host.data, sni_ctx->host.len);
-    *b->last++ = CR; *b->last++ = LF;
+    if (sni_ctx != NULL) {
+        b->last = ngx_cpymem(b->last, "Destination-SNI: ", sizeof("Destination-SNI: ") - 1);
+        b->last = ngx_copy(b->last, sni_ctx->host.data, sni_ctx->host.len);
+        *b->last++ = CR; *b->last++ = LF;
+    }
 
 #endif
     if (ahcf->header.len) {

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -1307,8 +1307,10 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
 #endif
 
 #if (NGX_MAIL_SNI_PROXY)
-    len += sizeof("Destination-SNI: ") - 1 + sni_ctx->host.len
-                + sizeof(CRLF) - 1;
+    if (sni_ctx != NULL) {
+        len += sizeof("Destination-SNI: ") - 1 + sni_ctx->host.len
+                    + sizeof(CRLF) - 1;
+    }
 #endif
 
     b = ngx_create_temp_buf(pool, len);

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -832,6 +832,14 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
             ngx_memcpy(peer->name.data + len, ctx->port.data, ctx->port.len);
 
             ngx_destroy_pool(ctx->pool);
+            #if (NGX_MAIL_SNI_PROXY)
+                ngx_mail_sni_proxy_conf_t *snicf;
+                snicf = ngx_mail_get_module_srv_conf(s, ngx_mail_sni_proxy_module);
+                if(snicf->enable != NGX_CONF_UNSET) {
+                    ngx_mail_sni_proxy_connection_init(s, peer);
+                    return;
+                }
+            #endif
             ngx_mail_proxy_init(s, peer);
 
             return;

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -298,6 +298,21 @@ ngx_mail_init_session_handler(ngx_event_t *rev)
     ngx_mail_init_session(c);
 }
 
+#if (NGX_MAIL_SNI_PROXY)
+void
+ngx_mail_sni_starttls_handler(ngx_event_t *rev)
+{
+    ngx_connection_t *c;
+    ngx_mail_session_t *s;
+
+    c = rev->data;
+    s = c->data;
+
+    c->log->action = "in sni starttls snoop state";
+
+    ngx_mail_init_sni_snoop(s, c);
+}
+#endif
 
 #if (NGX_MAIL_SSL)
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -304,13 +304,13 @@ ngx_mail_sni_starttls_handler(ngx_event_t *rev)
 {
     ngx_connection_t                   *c;
     ngx_mail_session_t                 *s;
-    ngx_int_t                          rc;
 
     c = rev->data;
     s = c->data;
 
     c->log->action = "in sni starttls snoop state";
    
+   ngx_mail_init_sni_snoop(s, c);
 }
 #endif
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -302,15 +302,18 @@ ngx_mail_init_session_handler(ngx_event_t *rev)
 void
 ngx_mail_sni_starttls_handler(ngx_event_t *rev)
 {
-    ngx_connection_t *c;
-    ngx_mail_session_t *s;
+    ngx_connection_t                   *c;
+    ngx_mail_session_t                 *s;
+    ngx_int_t                          rc;
+    ngx_mail_sni_proxy_ctx_t           *ctx;
 
     c = rev->data;
     s = c->data;
 
     c->log->action = "in sni starttls snoop state";
 
-    ngx_mail_init_sni_snoop(s, c);
+    rc = ngx_mail_init_sni_snoop(s, c);
+   
 }
 #endif
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -305,14 +305,11 @@ ngx_mail_sni_starttls_handler(ngx_event_t *rev)
     ngx_connection_t                   *c;
     ngx_mail_session_t                 *s;
     ngx_int_t                          rc;
-    ngx_mail_sni_proxy_ctx_t           *ctx;
 
     c = rev->data;
     s = c->data;
 
     c->log->action = "in sni starttls snoop state";
-
-    rc = ngx_mail_init_sni_snoop(s, c);
    
 }
 #endif

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -649,7 +649,7 @@ ngx_mail_smtp_helo(ngx_mail_session_t *s, ngx_connection_t *c)
 #if (NGX_MAIL_SNI_PROXY)
         ngx_mail_sni_proxy_conf_t *snicf;
         snicf = ngx_mail_get_module_srv_conf(s, ngx_mail_sni_proxy_module);
-        if(snicf->enabled == NGX_CONF_SET) {
+        if(snicf->enable != NGX_CONF_UNSET) {
             s->out = sscf->starttls_only_capability;
             return NGX_OK;
         }

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -646,6 +646,15 @@ ngx_mail_smtp_helo(ngx_mail_session_t *s, ngx_connection_t *c)
         }
 #endif
 
+#if (NGX_MAIL_SNI_PROXY)
+        ngx_mail_sni_proxy_conf_t *snicf;
+        snicf = ngx_mail_get_module_srv_conf(s, ngx_mail_sni_proxy_module);
+        if(snicf->enabled == NGX_CONF_SET) {
+            s->out = sscf->starttls_only_capability;
+            return NGX_OK;
+        }
+#endif
+
         s->out = sscf->capability;
     }
 

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -878,10 +878,6 @@ ngx_mail_smtp_starttls(ngx_mail_session_t *s, ngx_connection_t *c)
     ngx_mail_sni_proxy_conf_t *snicf;
     snicf = ngx_mail_get_module_srv_conf(s, ngx_mail_sni_proxy_module);
     if(snicf->enable != NGX_CONF_UNSET) {
-         ngx_str_null(&s->smtp_helo);
-         ngx_str_null(&s->smtp_from);
-         ngx_str_null(&s->smtp_to);
-
          c->read->handler = ngx_mail_sni_starttls_handler;
          return NGX_OK;
     }

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -874,6 +874,19 @@ ngx_mail_smtp_starttls(ngx_mail_session_t *s, ngx_connection_t *c)
 
 #endif
 
+#if (NGX_MAIL_SNI_PROXY)
+    ngx_mail_sni_proxy_conf_t *snicf;
+    snicf = ngx_mail_get_module_srv_conf(s, ngx_mail_sni_proxy_module);
+    if(snicf->enable != NGX_CONF_UNSET) {
+         ngx_str_null(&s->smtp_helo);
+         ngx_str_null(&s->smtp_from);
+         ngx_str_null(&s->smtp_to);
+
+         c->read->handler = ngx_mail_sni_starttls_handler;
+         return NGX_OK;
+    }
+#endif
+
     return NGX_MAIL_PARSE_INVALID_COMMAND;
 }
 

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -1107,6 +1107,7 @@ ngx_mail_sni_proxy_send_xclient(ngx_mail_session_t *s, ngx_mail_sni_proxy_ctx_t 
                      s->connection->addr_text.len);
     b->last = ngx_cpymem(b->last, " NAME=", sizeof(" NAME=") - 1);
     b->last = ngx_copy(b->last, s->host.data, s->host.len);
+    b->last = ngx_cpymem(b->last, "\n", 1);
     c->send(c, b->pos, b->last-b->pos);
     b->pos = b->start;
     b->last = b->start;

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -109,8 +109,34 @@ ngx_mail_sni_proxy_enable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
-static void
+static ngx_int_t
 ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
+{
+    ngx_int_t                          rc;
+    ngx_mail_sni_proxy_ctx_t           *ctx;
+
+    rc = ngx_mail_init_sni_preread(s, c);
+
+    if (rc == NGX_AGAIN){
+        return rc;
+    }
+    if (rc != NGX_OK){
+        c->log->action = "bad tls client hello closing connection";
+        ngx_mail_close_connection(c);
+    }
+
+    ctx = ngx_mail_get_module_ctx(s, ngx_mail_sni_proxy_module);
+
+    if (ctx->host.len == 0){
+        c->log->action = "tls sni not found";
+        ngx_mail_close_connection(c);
+    }
+
+
+}
+
+static ngx_int_t
+ngx_mail_init_sni_preread(ngx_mail_session_t *s, ngx_connection_t *c)
 {
     u_char                             *last, *p;
     size_t                              len;
@@ -141,7 +167,7 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
             return NGX_ERROR;
         }
 
-        ngx_stream_set_ctx(s, ctx, ngx_mail_sni_proxy_module);
+        ngx_mail_set_ctx(s, ctx, ngx_mail_sni_proxy_module);
 
         ctx->pool = c->pool;
         ctx->log = c->log;
@@ -155,7 +181,7 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if ((p[0] & 0x80) && p[2] == 1 && (p[3] == 0 || p[3] == 3)) {
             ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
-                           "ssl preread: version 2 ClientHello");
+                           "tls preread: version 2 ClientHello");
             ctx->version[0] = p[3];
             ctx->version[1] = p[4];
             return NGX_OK;
@@ -163,15 +189,15 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if (p[0] != 0x16) {
             ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
-                           "ssl preread: not a handshake");
-            ngx_stream_set_ctx(s, NULL, ngx_stream_ssl_preread_module);
+                           "tls preread: not a handshake");
+            ngx_mail_set_ctx(s, NULL, ngx_mail_sni_proxy_module);
             return NGX_DECLINED;
         }
 
         if (p[1] != 3) {
             ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
-                           "ssl preread: unsupported SSL version");
-            ngx_stream_set_ctx(s, NULL, ngx_stream_ssl_preread_module);
+                           "tls preread: unsupported SSL version");
+            ngx_mail_set_ctx(s, NULL, ngx_mail_sni_proxy_module);
             return NGX_DECLINED;
         }
 
@@ -184,10 +210,10 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
 
         p += 5;
 
-        rc = ngx_stream_ssl_preread_parse_record(ctx, p, p + len);
+        rc = ngx_mail_sni_proxy_parse_record(ctx, p, p + len);
 
         if (rc == NGX_DECLINED) {
-            ngx_stream_set_ctx(s, NULL, ngx_stream_ssl_preread_module);
+            ngx_mail_set_ctx(s, NULL, ngx_mail_sni_proxy_module);
             return NGX_DECLINED;
         }
 
@@ -199,6 +225,301 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
     }
 
     ctx->pos = p;
+
+    return NGX_AGAIN;
+}
+
+static ngx_int_t
+ngx_mail_sni_proxy_parse_record(ngx_mail_sni_proxy_ctx_t *ctx,
+    u_char *pos, u_char *last)
+{
+    size_t   left, n, size, ext;
+    u_char  *dst, *p;
+
+    enum {
+        sw_start = 0,
+        sw_header,          /* handshake msg_type, length */
+        sw_version,         /* client_version */
+        sw_random,          /* random */
+        sw_sid_len,         /* session_id length */
+        sw_sid,             /* session_id */
+        sw_cs_len,          /* cipher_suites length */
+        sw_cs,              /* cipher_suites */
+        sw_cm_len,          /* compression_methods length */
+        sw_cm,              /* compression_methods */
+        sw_ext,             /* extension */
+        sw_ext_header,      /* extension_type, extension_data length */
+        sw_sni_len,         /* SNI length */
+        sw_sni_host_head,   /* SNI name_type, host_name length */
+        sw_sni_host,        /* SNI host_name */
+        sw_alpn_len,        /* ALPN length */
+        sw_alpn_proto_len,  /* ALPN protocol_name length */
+        sw_alpn_proto_data, /* ALPN protocol_name */
+        sw_supver_len       /* supported_versions length */
+    } state;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                   "tls preread: state %ui left %z", ctx->state, ctx->left);
+
+    state = ctx->state;
+    size = ctx->size;
+    left = ctx->left;
+    ext = ctx->ext;
+    dst = ctx->dst;
+    p = ctx->buf;
+
+    for ( ;; ) {
+        n = ngx_min((size_t) (last - pos), size);
+
+        if (dst) {
+            dst = ngx_cpymem(dst, pos, n);
+        }
+
+        pos += n;
+        size -= n;
+        left -= n;
+
+        if (size != 0) {
+            break;
+        }
+
+        switch (state) {
+
+        case sw_start:
+            state = sw_header;
+            dst = p;
+            size = 4;
+            left = size;
+            break;
+
+        case sw_header:
+            if (p[0] != 1) {
+                ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                               "tls preread: not a client hello");
+                return NGX_DECLINED;
+            }
+
+            state = sw_version;
+            dst = ctx->version;
+            size = 2;
+            left = (p[1] << 16) + (p[2] << 8) + p[3];
+            break;
+
+        case sw_version:
+            state = sw_random;
+            dst = NULL;
+            size = 32;
+            break;
+
+        case sw_random:
+            state = sw_sid_len;
+            dst = p;
+            size = 1;
+            break;
+
+        case sw_sid_len:
+            state = sw_sid;
+            dst = NULL;
+            size = p[0];
+            break;
+
+        case sw_sid:
+            state = sw_cs_len;
+            dst = p;
+            size = 2;
+            break;
+
+        case sw_cs_len:
+            state = sw_cs;
+            dst = NULL;
+            size = (p[0] << 8) + p[1];
+            break;
+
+        case sw_cs:
+            state = sw_cm_len;
+            dst = p;
+            size = 1;
+            break;
+
+        case sw_cm_len:
+            state = sw_cm;
+            dst = NULL;
+            size = p[0];
+            break;
+
+        case sw_cm:
+            if (left == 0) {
+                /* no extensions */
+                return NGX_OK;
+            }
+
+            state = sw_ext;
+            dst = p;
+            size = 2;
+            break;
+
+        case sw_ext:
+            if (left == 0) {
+                return NGX_OK;
+            }
+
+            state = sw_ext_header;
+            dst = p;
+            size = 4;
+            break;
+
+        case sw_ext_header:
+            if (p[0] == 0 && p[1] == 0 && ctx->host.data == NULL) {
+                /* SNI extension */
+                state = sw_sni_len;
+                dst = p;
+                size = 2;
+                break;
+            }
+
+            if (p[0] == 0 && p[1] == 16 && ctx->alpn.data == NULL) {
+                /* ALPN extension */
+                state = sw_alpn_len;
+                dst = p;
+                size = 2;
+                break;
+            }
+
+            if (p[0] == 0 && p[1] == 43) {
+                /* supported_versions extension */
+                state = sw_supver_len;
+                dst = p;
+                size = 1;
+                break;
+            }
+
+            state = sw_ext;
+            dst = NULL;
+            size = (p[2] << 8) + p[3];
+            break;
+
+        case sw_sni_len:
+            ext = (p[0] << 8) + p[1];
+            state = sw_sni_host_head;
+            dst = p;
+            size = 3;
+            break;
+
+        case sw_sni_host_head:
+            if (p[0] != 0) {
+                ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                               "tls preread: SNI hostname type is not DNS");
+                return NGX_DECLINED;
+            }
+
+            size = (p[1] << 8) + p[2];
+
+            if (ext < 3 + size) {
+                ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                               "tls preread: SNI format error");
+                return NGX_DECLINED;
+            }
+            ext -= 3 + size;
+
+            ctx->host.data = ngx_pnalloc(ctx->pool, size);
+            if (ctx->host.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            state = sw_sni_host;
+            dst = ctx->host.data;
+            break;
+
+        case sw_sni_host:
+            ctx->host.len = (p[1] << 8) + p[2];
+
+            ngx_log_debug1(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "tls preread: SNI hostname \"%V\"", &ctx->host);
+
+            state = sw_ext;
+            dst = NULL;
+            size = ext;
+            break;
+
+        case sw_alpn_len:
+            ext = (p[0] << 8) + p[1];
+
+            ctx->alpn.data = ngx_pnalloc(ctx->pool, ext);
+            if (ctx->alpn.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            state = sw_alpn_proto_len;
+            dst = p;
+            size = 1;
+            break;
+
+        case sw_alpn_proto_len:
+            size = p[0];
+
+            if (size == 0) {
+                ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                               "tls preread: ALPN empty protocol");
+                return NGX_DECLINED;
+            }
+
+            if (ext < 1 + size) {
+                ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                               "tls preread: ALPN format error");
+                return NGX_DECLINED;
+            }
+            ext -= 1 + size;
+
+            state = sw_alpn_proto_data;
+            dst = ctx->alpn.data + ctx->alpn.len;
+            break;
+
+        case sw_alpn_proto_data:
+            ctx->alpn.len += p[0];
+
+            ngx_log_debug1(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "tls preread: ALPN protocols \"%V\"", &ctx->alpn);
+
+            if (ext) {
+                ctx->alpn.data[ctx->alpn.len++] = ',';
+
+                state = sw_alpn_proto_len;
+                dst = p;
+                size = 1;
+                break;
+            }
+
+            state = sw_ext;
+            dst = NULL;
+            size = 0;
+            break;
+
+        case sw_supver_len:
+            ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "tls preread: supported_versions");
+
+            /* set TLSv1.3 */
+            ctx->version[0] = 3;
+            ctx->version[1] = 4;
+
+            state = sw_ext;
+            dst = NULL;
+            size = p[0];
+            break;
+        }
+
+        if (left < size) {
+            ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "tls preread: failed to parse handshake");
+            return NGX_DECLINED;
+        }
+    }
+
+    ctx->state = state;
+    ctx->size = size;
+    ctx->left = left;
+    ctx->ext = ext;
+    ctx->dst = dst;
 
     return NGX_AGAIN;
 }

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -14,7 +14,7 @@ static char *ngx_mail_sni_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *c
 static char *ngx_mail_sni_proxy_enable(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
-static ngx_command_t  ngx_mail_ssl_commands[] = {
+static ngx_command_t  ngx_mail_sni_proxy_commands[] = {
 
     { ngx_string("sni_proxy"),
       NGX_MAIL_SRV_CONF|NGX_CONF_FLAG,
@@ -75,9 +75,6 @@ ngx_mail_sni_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_mail_sni_proxy_conf_t *prev = parent;
     ngx_mail_sni_proxy_conf_t *conf = child;
 
-    char                *mode;
-    ngx_pool_cleanup_t  *cln;
-
     ngx_conf_merge_value(conf->enable, prev->enable, 0);
 
     return NGX_CONF_OK;
@@ -87,8 +84,6 @@ ngx_mail_sni_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 static char *
 ngx_mail_sni_proxy_enable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_mail_sni_proxy_conf_t  *spcf = conf;
-
     char  *rv;
 
     rv = ngx_conf_set_flag_slot(cf, cmd, conf);

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -1150,7 +1150,8 @@ ngx_mail_sni_proxy_send_hello_upstream(ngx_mail_session_t *s, ngx_mail_sni_proxy
 
     c = spc->upstream.connection;
     b = spc->proxy_buffer;
-    b->last = ngx_cpymem(b->last, s->smtp_helo.data, s->smtp_helo.len);
+    b->last = ngx_cpymem(b->last, "EHLO ", 5);
+    b->last = ngx_copy(b->last, s->smtp_helo.data, s->smtp_helo.len);
     b->last = ngx_cpymem(b->last, "\n", 1);
     c->send(c, b->pos, b->last-b->pos);
     b->pos = b->start;

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -1,0 +1,101 @@
+
+/*
+ * Copyright (C) Srujith Kudikala
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_mail.h>
+
+static void *ngx_mail_sni_proxy_create_conf(ngx_conf_t *cf);
+static char *ngx_mail_sni_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *child);
+
+static char *ngx_mail_sni_proxy_enable(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+static ngx_command_t  ngx_mail_ssl_commands[] = {
+
+    { ngx_string("sni_proxy"),
+      NGX_MAIL_SRV_CONF|NGX_CONF_FLAG,
+      ngx_mail_sni_proxy_enable,
+      NGX_MAIL_SRV_CONF_OFFSET,
+      offsetof(ngx_mail_sni_proxy_conf_t, enable),
+      NULL },
+
+    ngx_null_command
+};
+
+
+static ngx_mail_module_t  ngx_mail_sni_proxy_module_ctx = {
+    NULL,                                  /* protocol */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    ngx_mail_sni_proxy_create_conf,        /* create server configuration */
+    ngx_mail_sni_proxy_merge_conf          /* merge server configuration */
+};
+
+
+ngx_module_t  ngx_mail_sni_proxy_module = {
+    NGX_MODULE_V1,
+    &ngx_mail_sni_proxy_module_ctx,        /* module context */
+    ngx_mail_sni_proxy_commands,           /* module directives */
+    NGX_MAIL_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+static void *
+ngx_mail_sni_proxy_create_conf(ngx_conf_t *cf)
+{
+    ngx_mail_sni_proxy_conf_t  *spcf;
+
+    spcf = ngx_pcalloc(cf->pool, sizeof(ngx_mail_sni_proxy_conf_t));
+    if (spcf == NULL) {
+        return NULL;
+    }
+
+    spcf->enable = NGX_CONF_UNSET;
+
+    return spcf;
+}
+
+
+static char *
+ngx_mail_sni_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_mail_sni_proxy_conf_t *prev = parent;
+    ngx_mail_sni_proxy_conf_t *conf = child;
+
+    char                *mode;
+    ngx_pool_cleanup_t  *cln;
+
+    ngx_conf_merge_value(conf->enable, prev->enable, 0);
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_mail_sni_proxy_enable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_mail_sni_proxy_conf_t  *spcf = conf;
+
+    char  *rv;
+
+    rv = ngx_conf_set_flag_slot(cf, cmd, conf);
+
+    if (rv != NGX_CONF_OK) {
+        return rv;
+    }
+
+    return NGX_CONF_OK;
+}

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -289,6 +289,9 @@ ngx_mail_init_sni_preread(ngx_mail_session_t *s, ngx_connection_t *c)
         }
 
         if (rc != NGX_AGAIN) {
+            ctx->pos = NULL;
+            s->buffer->pos = s->buffer->start;
+            s->buffer->last = s->buffer->start;
             return rc;
         }
 

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -178,8 +178,6 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
         ngx_mail_close_connection(c);
     }
 
-    s->host.data = ngx_pstrdup(c->pool, &ctx->host);
-    s->host.len = ctx->host.len;
     ngx_mail_auth_http_init(s);
     return rc;
 }

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -1148,6 +1148,7 @@ ngx_mail_sni_proxy_send_hello_upstream(ngx_mail_session_t *s, ngx_mail_sni_proxy
     c = spc->upstream.connection;
     b = spc->proxy_buffer;
     b->last = ngx_cpymem(b->last, s->smtp_helo.data, s->smtp_helo.len);
+    b->last = ngx_cpymem(b->last, "\n", 1);
     c->send(c, b->pos, b->last-b->pos);
     b->pos = b->start;
     b->last = b->start;

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -132,7 +132,9 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
         ngx_mail_close_connection(c);
     }
 
-
+    s->host.data = ngx_pstrdup(c->pool, &ctx->host);
+    s->host.len = &ctx->host.len;
+    ngx_mail_auth_http_init(s);
 }
 
 static ngx_int_t

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -8,26 +8,6 @@
 #include <ngx_core.h>
 #include <ngx_mail.h>
 
-
-
-typedef struct {
-    size_t          left;
-    size_t          size;
-    size_t          ext;
-    u_char         *pos;
-    u_char         *dst;
-    u_char          buf[4];
-    u_char          version[2];
-    ngx_str_t       host;
-    ngx_str_t       alpn;
-    ngx_log_t      *log;
-    ngx_pool_t     *pool;
-    ngx_uint_t      state;
-    ngx_peer_connection_t upstream;
-    ngx_buf_t              *proxy_buffer;
-    ngx_buf_t       *tls_header;
-} ngx_mail_sni_proxy_ctx_t;
-
 static void *ngx_mail_sni_proxy_create_conf(ngx_conf_t *cf);
 static char *ngx_mail_sni_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *child);
 static ngx_int_t

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -709,6 +709,9 @@ ngx_mail_sni_proxy_handle_upsteam_read(ngx_event_t *wev)
             break;
         case ngx_smtp_starttls:
             if (ngx_mail_sni_proxy_starttls_response(s, spc) == NGX_OK ){
+                ngx_str_null(&s->smtp_helo);
+                ngx_str_null(&s->smtp_from);
+                ngx_str_null(&s->smtp_to);
                 s->connection->read->handler = ngx_mail_sni_proxy_handler;
                 spc->upstream.connection->read->handler = ngx_mail_sni_proxy_handler;
             }

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -1147,10 +1147,7 @@ ngx_mail_sni_proxy_send_hello_upstream(ngx_mail_session_t *s, ngx_mail_sni_proxy
 
     c = spc->upstream.connection;
     b = spc->proxy_buffer;
-    b->last = ngx_cpymem(b->last, "HELO ", 5);
-    //TODO validate buffer is atleast the size of host + 6
-    b->last = ngx_cpymem(b->last, s->host.data, s->host.len);
-    b->last = ngx_cpymem(b->last, "\n", 1);
+    b->last = ngx_cpymem(b->last, s->smtp_helo.data, s->smtp_helo.len);
     c->send(c, b->pos, b->last-b->pos);
     b->pos = b->start;
     b->last = b->start;

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -149,13 +149,13 @@ ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
     if (rc != NGX_OK){
         c->log->action = "bad tls client hello closing connection";
         ngx_mail_close_connection(c);
+        return NGX_ERROR;
     }
 
     ctx = ngx_mail_get_module_ctx(s, ngx_mail_sni_proxy_module);
 
     if (ctx->host.len == 0){
         c->log->action = "tls sni not found";
-        ngx_mail_close_connection(c);
     }
 
     ngx_mail_auth_http_init(s);

--- a/src/mail/ngx_mail_sni_proxy_module.c
+++ b/src/mail/ngx_mail_sni_proxy_module.c
@@ -37,6 +37,20 @@ static ngx_mail_module_t  ngx_mail_sni_proxy_module_ctx = {
     ngx_mail_sni_proxy_merge_conf          /* merge server configuration */
 };
 
+typedef struct {
+    size_t          left;
+    size_t          size;
+    size_t          ext;
+    u_char         *pos;
+    u_char         *dst;
+    u_char          buf[4];
+    u_char          version[2];
+    ngx_str_t       host;
+    ngx_str_t       alpn;
+    ngx_log_t      *log;
+    ngx_pool_t     *pool;
+    ngx_uint_t      state;
+} ngx_mail_sni_proxy_ctx_t;
 
 ngx_module_t  ngx_mail_sni_proxy_module = {
     NGX_MODULE_V1,
@@ -93,4 +107,98 @@ ngx_mail_sni_proxy_enable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     return NGX_CONF_OK;
+}
+
+static void
+ngx_mail_init_sni_snoop(ngx_mail_session_t *s, ngx_connection_t *c)
+{
+    u_char                             *last, *p;
+    size_t                              len;
+    ngx_int_t                           rc;
+    ngx_mail_sni_proxy_ctx_t           *ctx;
+    ngx_mail_sni_proxy_conf_t          *conf;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0, "tls preread handler");
+
+    conf = ngx_mail_get_module_srv_conf(s, ngx_mail_sni_proxy_module);
+
+    if (!conf->enable) {
+        return NGX_DECLINED;
+    }
+
+    if (c->type != SOCK_STREAM) {
+        return NGX_DECLINED;
+    }
+
+    if (c->buffer == NULL) {
+        return NGX_AGAIN;
+    }
+
+    ctx = ngx_mail_get_module_ctx(s, ngx_mail_sni_proxy_module);
+    if (ctx == NULL) {
+        ctx = ngx_pcalloc(c->pool, sizeof(ngx_mail_sni_proxy_module));
+        if (ctx == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_stream_set_ctx(s, ctx, ngx_mail_sni_proxy_module);
+
+        ctx->pool = c->pool;
+        ctx->log = c->log;
+        ctx->pos = c->buffer->pos;
+    }
+
+    p = ctx->pos;
+    last = c->buffer->last;
+
+    while (last - p >= 5) {
+
+        if ((p[0] & 0x80) && p[2] == 1 && (p[3] == 0 || p[3] == 3)) {
+            ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "ssl preread: version 2 ClientHello");
+            ctx->version[0] = p[3];
+            ctx->version[1] = p[4];
+            return NGX_OK;
+        }
+
+        if (p[0] != 0x16) {
+            ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "ssl preread: not a handshake");
+            ngx_stream_set_ctx(s, NULL, ngx_stream_ssl_preread_module);
+            return NGX_DECLINED;
+        }
+
+        if (p[1] != 3) {
+            ngx_log_debug0(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
+                           "ssl preread: unsupported SSL version");
+            ngx_stream_set_ctx(s, NULL, ngx_stream_ssl_preread_module);
+            return NGX_DECLINED;
+        }
+
+        len = (p[3] << 8) + p[4];
+
+        /* read the whole record before parsing */
+        if ((size_t) (last - p) < len + 5) {
+            break;
+        }
+
+        p += 5;
+
+        rc = ngx_stream_ssl_preread_parse_record(ctx, p, p + len);
+
+        if (rc == NGX_DECLINED) {
+            ngx_stream_set_ctx(s, NULL, ngx_stream_ssl_preread_module);
+            return NGX_DECLINED;
+        }
+
+        if (rc != NGX_AGAIN) {
+            return rc;
+        }
+
+        p += len;
+    }
+
+    ctx->pos = p;
+
+    return NGX_AGAIN;
 }

--- a/src/mail/ngx_mail_sni_proxy_module.h
+++ b/src/mail/ngx_mail_sni_proxy_module.h
@@ -14,6 +14,7 @@
 
 typedef struct {
     ngx_flag_t       enable;
+    size_t      buffer_size;
 } ngx_mail_sni_proxy_conf_t;
 
 extern ngx_module_t  ngx_mail_sni_proxy_module;

--- a/src/mail/ngx_mail_sni_proxy_module.h
+++ b/src/mail/ngx_mail_sni_proxy_module.h
@@ -1,0 +1,22 @@
+
+/*
+ * Copyright (C) Srujith Kudikala
+ */
+
+
+#ifndef _NGX_MAIL_SNI_PROXY_H_INCLUDED_
+#define _NGX_MAIL_SNI_PROXY_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_mail.h>
+
+typedef struct {
+    ngx_flag_t       enable;
+} ngx_mail_sni_proxy_conf_t;
+
+extern ngx_module_t  ngx_mail_sni_proxy_module;
+
+
+#endif /* _NGX_MAIL_SNI_PROXY_H_INCLUDED__ */

--- a/src/mail/ngx_mail_sni_proxy_module.h
+++ b/src/mail/ngx_mail_sni_proxy_module.h
@@ -17,6 +17,24 @@ typedef struct {
     size_t      buffer_size;
 } ngx_mail_sni_proxy_conf_t;
 
+typedef struct {
+    size_t          left;
+    size_t          size;
+    size_t          ext;
+    u_char         *pos;
+    u_char         *dst;
+    u_char          buf[4];
+    u_char          version[2];
+    ngx_str_t       host;
+    ngx_str_t       alpn;
+    ngx_log_t      *log;
+    ngx_pool_t     *pool;
+    ngx_uint_t      state;
+    ngx_peer_connection_t upstream;
+    ngx_buf_t              *proxy_buffer;
+    ngx_buf_t       *tls_header;
+} ngx_mail_sni_proxy_ctx_t;
+
 extern ngx_module_t  ngx_mail_sni_proxy_module;
 
 


### PR DESCRIPTION
The goal is to allow proxing StartTLS SMTP connections without the nginx instance being aware of the TLS keys.